### PR TITLE
Fix prio mask

### DIFF
--- a/include/can_interface.h
+++ b/include/can_interface.h
@@ -79,7 +79,7 @@ public:
         ExtendedId(uint8_t source_address, PGN pgn, uint8_t priority)
             : extended_id{.source_address = source_address,
                           .pgn = static_cast<uint32_t>(pgn & 0x3FFFF),
-                          .priority = static_cast<uint8_t>(priority & 0b11)
+                          .priority = static_cast<uint8_t>(priority & 0b111)
 
             }
         {


### PR DESCRIPTION
The previous mask was just using 0b11, but the priority is 3 bits.